### PR TITLE
fix: auto-add new files when committing and amending

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# SaplingMcp
+
+A Model Context Protocol (MCP) server for Sapling SCM integration.
+
+## Token-Efficient Parsing Format
+
+This project implements a token-efficient line-based parsing format for the MCP server that handles stack information and PR comments for Sapling SCM. The format is designed to be compact and efficient when interacting with LLMs.
+
+### Stack Information Format
+
+Stack information is formatted using a pipe-delimited structure:
+
+```
+sha:<commit-sha>|title:<commit-title>|pr:<owner/repo#number or none>
+```
+
+Example:
+```
+sha:abc123def456|title:Fix widget rendering bug|pr:your-org/your-repo#123
+```
+
+### PR Comments Format
+
+PR comments are formatted with a similar pipe-delimited structure:
+
+```
+pr:<owner/repo#number>|author:<username>|date:<timestamp>|id:<comment-id>|body:<comment-text>
+```
+
+Example:
+```
+pr:your-org/your-repo#123|author:username|date:2025-04-20T14:30:00Z|id:comment123|body:This looks good.\nJust one suggestion: let's add more tests.
+```
+
+### Special Characters
+
+- Newlines in comments are escaped as `\\n` to maintain the line-based format
+- Each item is on a separate line, making it easy to process line by line
+
+### Usage
+
+The MCP server provides token-efficient versions of the following endpoints:
+
+- `GetCurrentStack`: Gets all commits in the current stack in token-efficient format
+- `GetPublicCommits`: Gets all public commits in token-efficient format
+- `CreateCommit`: Creates a new commit and returns it in token-efficient format
+- `AmendCommit`: Amends the current commit and returns it in token-efficient format
+
+These endpoints return strings in the token-efficient format described above, which can be parsed using the `TokenEfficientParser` class.
+
+## Building and Running
+
+```bash
+# Build the project
+dotnet build
+
+# Run the server
+dotnet run --project SaplingMcp.Server
+
+# Run tests
+dotnet test
+```

--- a/SaplingMcp.Server/SaplingTools.cs
+++ b/SaplingMcp.Server/SaplingTools.cs
@@ -29,9 +29,9 @@ public class SaplingTools
     }
 
     [McpServerTool, Description("Gets all the commits in the current stack")]
-    public List<Commit> GetCurrentStack(string message = "")
+    public string GetCurrentStack(string message = "")
     {
-        return _sapling.Stack().ToList();
+        return TokenEfficientParser.FormatCommits(_sapling.Stack().ToList());
     }
 
     [McpServerTool, Description("Gets all the public commits")]
@@ -41,7 +41,7 @@ public class SaplingTools
     }
 
     [McpServerTool, Description("Creates a new commit with the specified message and files")]
-    public Commit CreateCommit(
+    public string CreateCommit(
         [Description("The commit message to use")] string message,
         [Description("List of files to include in the commit")] List<string> files)
     {
@@ -52,7 +52,8 @@ public class SaplingTools
             {
                 throw new InvalidOperationException("Failed to create commit. Please check your repository state.");
             }
-            return commit;
+
+            return TokenEfficientParser.FormatCommit(commit);
         }
         catch (Exception ex)
         {
@@ -61,7 +62,7 @@ public class SaplingTools
     }
 
     [McpServerTool, Description("Amends the current commit with the specified files and optionally updates the commit message")]
-    public Commit AmendCommit(
+    public string AmendCommit(
         [Description("List of files to include in the amendment")] List<string> files,
         [Description("The new commit message (optional). If not provided, the existing message is kept")] string? message = null)
     {
@@ -72,7 +73,8 @@ public class SaplingTools
             {
                 throw new InvalidOperationException("Failed to amend commit. Please check your repository state.");
             }
-            return commit;
+
+            return TokenEfficientParser.FormatCommit(commit);
         }
         catch (Exception ex)
         {
@@ -81,7 +83,7 @@ public class SaplingTools
     }
 
     [McpServerTool, Description("Gets the status of files in the working directory")]
-    public List<FileStatus> GetStatus()
+    public List<FileStatus> GetStatus(string message = "")
     {
         try
         {

--- a/SaplingMcp.Server/Services/Sapling.cs
+++ b/SaplingMcp.Server/Services/Sapling.cs
@@ -198,7 +198,7 @@ public class Sapling
         }
 
         // Create the commit with the specified files
-        var commitArguments = new List<string> { "commit", "-m", message };
+        var commitArguments = new List<string> { "commit", "-Am", message };
 
         // Add each file with the -I flag
         foreach (var file in files)
@@ -229,7 +229,7 @@ public class Sapling
         }
 
         // Create the amend command with the specified files
-        var amendArguments = new List<string> { "amend" };
+        var amendArguments = new List<string> { "amend", "-A" };
 
         // Add message if provided
         if (!string.IsNullOrEmpty(message))

--- a/SaplingMcp.Server/Services/TokenEfficientParser.cs
+++ b/SaplingMcp.Server/Services/TokenEfficientParser.cs
@@ -1,0 +1,250 @@
+using System.Text;
+
+namespace SaplingMcp.Server.Services;
+
+/// <summary>
+/// Provides token-efficient parsing and formatting for MCP server data structures.
+/// </summary>
+public static class TokenEfficientParser
+{
+    private const char Delimiter = '|';
+    private const string NewlineEscape = "\\n";
+
+    /// <summary>
+    /// Formats a commit into a token-efficient line-based format.
+    /// </summary>
+    /// <param name="commit">The commit to format.</param>
+    /// <returns>A string representation of the commit in the format: sha:<commit-sha>|title:<commit-title>|pr:<owner/repo#number or none></returns>
+    public static string FormatCommit(Commit commit)
+    {
+        var sb = new StringBuilder();
+
+        sb.Append("sha:").Append(commit.Node);
+        sb.Append(Delimiter);
+
+        // Only use the first line of the commit message to keep tokens down
+        string firstLine = commit.Description.Split(new[] { '\n' }, 2)[0];
+        sb.Append("title:").Append(EscapeValue(firstLine));
+        sb.Append(Delimiter);
+
+        sb.Append("pr:");
+        if (commit.GitHubPullRequestNumber.HasValue &&
+            !string.IsNullOrEmpty(commit.GitHubPullRequestRepoOwner) &&
+            !string.IsNullOrEmpty(commit.GitHubPullRequestRepoName))
+        {
+            sb.Append($"{commit.GitHubPullRequestRepoOwner}/{commit.GitHubPullRequestRepoName}#{commit.GitHubPullRequestNumber}");
+        }
+        else
+        {
+            sb.Append("none");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Parses a token-efficient line-based format into a commit.
+    /// </summary>
+    /// <param name="line">The line to parse.</param>
+    /// <returns>A commit object.</returns>
+    public static Commit ParseCommit(string line)
+    {
+        var parts = SplitLine(line);
+        var commit = new Commit
+        {
+            Node = GetValue(parts, "sha"),
+            Description = UnescapeValue(GetValue(parts, "title")),
+            Author = string.Empty, // Not included in compact format
+            FilesAdded = new List<string>(),
+            FilesRemoved = new List<string>(),
+            FilesModified = new List<string>(),
+            Phase = string.Empty // Not included in compact format
+        };
+
+        var prValue = GetValue(parts, "pr");
+        if (prValue != "none")
+        {
+            // Parse PR in format owner/repo#number
+            var prParts = prValue.Split('#');
+            if (prParts.Length == 2)
+            {
+                var repoPath = prParts[0].Split('/');
+                if (repoPath.Length == 2 && int.TryParse(prParts[1], out int prNumber))
+                {
+                    commit.GitHubPullRequestRepoOwner = repoPath[0];
+                    commit.GitHubPullRequestRepoName = repoPath[1];
+                    commit.GitHubPullRequestNumber = prNumber;
+                }
+            }
+        }
+
+        return commit;
+    }
+
+    /// <summary>
+    /// Formats a pull request comment into a token-efficient line-based format.
+    /// </summary>
+    /// <param name="comment">The comment to format.</param>
+    /// <param name="prNumber">The pull request number.</param>
+    /// <param name="repoPath">The repository path in format owner/repo.</param>
+    /// <returns>A string representation of the comment in the format: pr:<owner/repo#number>|author:<username>|date:<timestamp>|id:<comment-id>|body:<comment-text></returns>
+    public static string FormatPullRequestComment(PullRequestComment comment, int prNumber, string repoPath)
+    {
+        var sb = new StringBuilder();
+
+        sb.Append("pr:").Append(repoPath).Append('#').Append(prNumber);
+        sb.Append(Delimiter);
+
+        // Extract author from URL (this is a simplification, in a real implementation you'd want to get this from the API)
+        var authorPlaceholder = "unknown";
+        sb.Append("author:").Append(authorPlaceholder);
+        sb.Append(Delimiter);
+
+        sb.Append("date:").Append(comment.CreatedAt);
+        sb.Append(Delimiter);
+
+        // Extract ID from URL (this is a simplification, in a real implementation you'd want to get this from the API)
+        var idParts = comment.Url.Split('/');
+        var id = idParts.Length > 0 ? idParts[idParts.Length - 1] : "unknown";
+        sb.Append("id:").Append(id);
+        sb.Append(Delimiter);
+
+        sb.Append("body:").Append(EscapeValue(comment.Body));
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Parses a token-efficient line-based format into a pull request comment.
+    /// </summary>
+    /// <param name="line">The line to parse.</param>
+    /// <returns>A tuple containing the pull request comment, PR number, and repository path.</returns>
+    public static (PullRequestComment Comment, int PrNumber, string RepoPath) ParsePullRequestComment(string line)
+    {
+        var parts = SplitLine(line);
+
+        var prValue = GetValue(parts, "pr");
+        var prParts = prValue.Split('#');
+        var repoPath = prParts[0];
+        var prNumber = int.Parse(prParts[1]);
+
+        var comment = new PullRequestComment
+        {
+            Body = UnescapeValue(GetValue(parts, "body")),
+            CreatedAt = GetValue(parts, "date"),
+            Url = $"https://github.com/{repoPath}/pull/{prNumber}/comments/{GetValue(parts, "id")}",
+            DiffHunk = string.Empty // Not included in compact format
+        };
+
+        return (comment, prNumber, repoPath);
+    }
+
+    /// <summary>
+    /// Formats a list of commits into a token-efficient multi-line format.
+    /// </summary>
+    /// <param name="commits">The list of commits to format.</param>
+    /// <returns>A string representation of the commits, one per line.</returns>
+    public static string FormatCommits(IEnumerable<Commit> commits)
+    {
+        return string.Join(Environment.NewLine, commits.Select(FormatCommit));
+    }
+
+    /// <summary>
+    /// Parses a token-efficient multi-line format into a list of commits.
+    /// </summary>
+    /// <param name="text">The text to parse.</param>
+    /// <returns>A list of commit objects.</returns>
+    public static List<Commit> ParseCommits(string text)
+    {
+        return text.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(ParseCommit)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Formats a list of pull request comments into a token-efficient multi-line format.
+    /// </summary>
+    /// <param name="comments">The list of comments to format.</param>
+    /// <param name="prNumber">The pull request number.</param>
+    /// <param name="repoPath">The repository path in format owner/repo.</param>
+    /// <returns>A string representation of the comments, one per line.</returns>
+    public static string FormatPullRequestComments(IEnumerable<PullRequestComment> comments, int prNumber, string repoPath)
+    {
+        return string.Join(Environment.NewLine, comments.Select(c => FormatPullRequestComment(c, prNumber, repoPath)));
+    }
+
+    /// <summary>
+    /// Parses a token-efficient multi-line format into a list of pull request comments.
+    /// </summary>
+    /// <param name="text">The text to parse.</param>
+    /// <returns>A list of tuples containing pull request comments, PR numbers, and repository paths.</returns>
+    public static List<(PullRequestComment Comment, int PrNumber, string RepoPath)> ParsePullRequestComments(string text)
+    {
+        return text.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(ParsePullRequestComment)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Escapes special characters in a value for the token-efficient format.
+    /// </summary>
+    /// <param name="value">The value to escape.</param>
+    /// <returns>The escaped value.</returns>
+    private static string EscapeValue(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Replace("\n", NewlineEscape);
+    }
+
+    /// <summary>
+    /// Unescapes special characters in a value from the token-efficient format.
+    /// </summary>
+    /// <param name="value">The value to unescape.</param>
+    /// <returns>The unescaped value.</returns>
+    private static string UnescapeValue(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Replace(NewlineEscape, "\n");
+    }
+
+    /// <summary>
+    /// Splits a line into key-value pairs.
+    /// </summary>
+    /// <param name="line">The line to split.</param>
+    /// <returns>A dictionary of key-value pairs.</returns>
+    private static Dictionary<string, string> SplitLine(string line)
+    {
+        var result = new Dictionary<string, string>();
+        var parts = line.Split(Delimiter);
+
+        foreach (var part in parts)
+        {
+            var keyValue = part.Split(new[] { ':' }, 2);
+            if (keyValue.Length == 2)
+            {
+                result[keyValue[0]] = keyValue[1];
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets a value from a dictionary of key-value pairs.
+    /// </summary>
+    /// <param name="parts">The dictionary of key-value pairs.</param>
+    /// <param name="key">The key to get the value for.</param>
+    /// <returns>The value, or an empty string if the key is not found.</returns>
+    private static string GetValue(Dictionary<string, string> parts, string key)
+    {
+        return parts.TryGetValue(key, out var value) ? value : string.Empty;
+    }
+}

--- a/SaplingMcp.Tests/SaplingMcp.Tests.csproj
+++ b/SaplingMcp.Tests/SaplingMcp.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SaplingMcp.Server\SaplingMcp.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SaplingMcp.Tests/TokenEfficientParserTests.cs
+++ b/SaplingMcp.Tests/TokenEfficientParserTests.cs
@@ -1,0 +1,223 @@
+using SaplingMcp.Server.Services;
+using Xunit;
+
+namespace SaplingMcp.Tests;
+
+public class TokenEfficientParserTests
+{
+    [Fact]
+    public void FormatCommit_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        var commit = new Commit
+        {
+            Node = "abc123def456",
+            Description = "Fix widget rendering bug",
+            Author = "John Doe",
+            FilesAdded = new List<string>(),
+            FilesRemoved = new List<string>(),
+            FilesModified = new List<string>(),
+            Phase = "draft",
+            GitHubPullRequestNumber = 123,
+            GitHubPullRequestRepoOwner = "your-org",
+            GitHubPullRequestRepoName = "your-repo"
+        };
+
+        // Act
+        var result = TokenEfficientParser.FormatCommit(commit);
+
+        // Assert
+        Assert.Equal("sha:abc123def456|title:Fix widget rendering bug|pr:your-org/your-repo#123", result);
+    }
+
+    [Fact]
+    public void FormatCommit_WithoutPR_ShouldReturnNoneForPR()
+    {
+        // Arrange
+        var commit = new Commit
+        {
+            Node = "abc123def456",
+            Description = "Fix widget rendering bug",
+            Author = "John Doe",
+            FilesAdded = new List<string>(),
+            FilesRemoved = new List<string>(),
+            FilesModified = new List<string>(),
+            Phase = "draft"
+        };
+
+        // Act
+        var result = TokenEfficientParser.FormatCommit(commit);
+
+        // Assert
+        Assert.Equal("sha:abc123def456|title:Fix widget rendering bug|pr:none", result);
+    }
+
+    [Fact]
+    public void ParseCommit_ShouldReturnCorrectObject()
+    {
+        // Arrange
+        var line = "sha:abc123def456|title:Fix widget rendering bug|pr:your-org/your-repo#123";
+
+        // Act
+        var result = TokenEfficientParser.ParseCommit(line);
+
+        // Assert
+        Assert.Equal("abc123def456", result.Node);
+        Assert.Equal("Fix widget rendering bug", result.Description);
+        Assert.Equal(123, result.GitHubPullRequestNumber);
+        Assert.Equal("your-org", result.GitHubPullRequestRepoOwner);
+        Assert.Equal("your-repo", result.GitHubPullRequestRepoName);
+    }
+
+    [Fact]
+    public void ParseCommit_WithoutPR_ShouldReturnNullPRNumber()
+    {
+        // Arrange
+        var line = "sha:abc123def456|title:Fix widget rendering bug|pr:none";
+
+        // Act
+        var result = TokenEfficientParser.ParseCommit(line);
+
+        // Assert
+        Assert.Equal("abc123def456", result.Node);
+        Assert.Equal("Fix widget rendering bug", result.Description);
+        Assert.Null(result.GitHubPullRequestNumber);
+        Assert.Null(result.GitHubPullRequestRepoOwner);
+        Assert.Null(result.GitHubPullRequestRepoName);
+    }
+
+    [Fact]
+    public void FormatPullRequestComment_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        var comment = new PullRequestComment
+        {
+            Body = "This looks good.\nJust one suggestion: let's add more tests.",
+            CreatedAt = "2025-04-20T14:30:00Z",
+            Url = "https://github.com/your-org/your-repo/pull/123/comments/comment123",
+            DiffHunk = "diff --git a/file.txt b/file.txt"
+        };
+
+        // Act
+        var result = TokenEfficientParser.FormatPullRequestComment(comment, 123, "your-org/your-repo");
+
+        // Assert
+        Assert.Equal("pr:your-org/your-repo#123|author:unknown|date:2025-04-20T14:30:00Z|id:comment123|body:This looks good.\\nJust one suggestion: let's add more tests.", result);
+    }
+
+    [Fact]
+    public void ParsePullRequestComment_ShouldReturnCorrectObject()
+    {
+        // Arrange
+        var line = "pr:your-org/your-repo#123|author:username|date:2025-04-20T14:30:00Z|id:comment123|body:This looks good.\\nJust one suggestion: let's add more tests.";
+
+        // Act
+        var (comment, prNumber, repoPath) = TokenEfficientParser.ParsePullRequestComment(line);
+
+        // Assert
+        Assert.Equal("This looks good.\nJust one suggestion: let's add more tests.", comment.Body);
+        Assert.Equal("2025-04-20T14:30:00Z", comment.CreatedAt);
+        Assert.Contains("comment123", comment.Url);
+        Assert.Equal(123, prNumber);
+        Assert.Equal("your-org/your-repo", repoPath);
+    }
+
+    [Fact]
+    public void FormatCommits_ShouldReturnMultilineFormat()
+    {
+        // Arrange
+        var commits = new List<Commit>
+        {
+            new Commit
+            {
+                Node = "abc123",
+                Description = "Fix bug",
+                Author = "John",
+                FilesAdded = new List<string>(),
+                FilesRemoved = new List<string>(),
+                FilesModified = new List<string>(),
+                Phase = "draft",
+                GitHubPullRequestNumber = 123,
+                GitHubPullRequestRepoOwner = "org1",
+                GitHubPullRequestRepoName = "repo1"
+            },
+            new Commit
+            {
+                Node = "def456",
+                Description = "Add feature",
+                Author = "Jane",
+                FilesAdded = new List<string>(),
+                FilesRemoved = new List<string>(),
+                FilesModified = new List<string>(),
+                Phase = "draft"
+            }
+        };
+
+        // Act
+        var result = TokenEfficientParser.FormatCommits(commits);
+        var lines = result.Split(Environment.NewLine);
+
+        // Assert
+        Assert.Equal(2, lines.Length);
+        Assert.Equal("sha:abc123|title:Fix bug|pr:org1/repo1#123", lines[0]);
+        Assert.Equal("sha:def456|title:Add feature|pr:none", lines[1]);
+    }
+
+    [Fact]
+    public void ParseCommits_ShouldReturnListOfCommits()
+    {
+        // Arrange
+        var text = "sha:abc123|title:Fix bug|pr:org1/repo1#123" + Environment.NewLine +
+                   "sha:def456|title:Add feature|pr:none";
+
+        // Act
+        var result = TokenEfficientParser.ParseCommits(text);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("abc123", result[0].Node);
+        Assert.Equal("Fix bug", result[0].Description);
+        Assert.Equal(123, result[0].GitHubPullRequestNumber);
+        Assert.Equal("org1", result[0].GitHubPullRequestRepoOwner);
+        Assert.Equal("repo1", result[0].GitHubPullRequestRepoName);
+        
+        Assert.Equal("def456", result[1].Node);
+        Assert.Equal("Add feature", result[1].Description);
+        Assert.Null(result[1].GitHubPullRequestNumber);
+    }
+
+    [Fact]
+    public void FormatCommit_ShouldOnlyUseFirstLine()
+    {
+        // Arrange
+        var commit = new Commit
+        {
+            Node = "abc123",
+            Description = "Line 1\nLine 2\nLine 3",
+            Author = "John",
+            FilesAdded = new List<string>(),
+            FilesRemoved = new List<string>(),
+            FilesModified = new List<string>(),
+            Phase = "draft"
+        };
+
+        // Act
+        var result = TokenEfficientParser.FormatCommit(commit);
+
+        // Assert
+        Assert.Equal("sha:abc123|title:Line 1|pr:none", result);
+    }
+
+    [Fact]
+    public void UnescapeValue_ShouldHandleEscapedNewlines()
+    {
+        // Arrange
+        var line = "sha:abc123|title:Line 1\\nLine 2\\nLine 3|pr:none";
+
+        // Act
+        var result = TokenEfficientParser.ParseCommit(line);
+
+        // Assert
+        Assert.Equal("Line 1\nLine 2\nLine 3", result.Description);
+    }
+}


### PR DESCRIPTION

Summary:

Fixed an issue where new files were not being automatically added when
committing or amending. Added the -A flag to both commit and amend commands to
ensure all new files are properly tracked.

Test Plan:

1. Create a new file in the repository
2. Run commit or amend command with the file path
3. Verify the file is properly added to the commit
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/SaplingMcp/pull/5).
* #8
* #7
* #6
* __->__ #5
* #4