### PR TITLE
feat: add ability to submit the current stack

### DIFF
--- a/SaplingMcp.Server/SaplingTools.cs
+++ b/SaplingMcp.Server/SaplingTools.cs
@@ -94,4 +94,23 @@ public class SaplingTools
             throw new InvalidOperationException($"Error getting status: {ex.Message}");
         }
     }
+
+    [McpServerTool, Description("Submits the current stack of commits to create or update pull requests")]
+    public string SubmitStack(string message = "")
+    {
+        try
+        {
+            var submittedCommits = _sapling.SubmitStack().ToList();
+            if (submittedCommits.Count == 0)
+            {
+                throw new InvalidOperationException("No commits were submitted. Please check your repository state.");
+            }
+
+            return TokenEfficientParser.FormatCommits(submittedCommits);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Error submitting stack: {ex.Message}");
+        }
+    }
 }

--- a/SaplingMcp.Server/Services/Sapling.cs
+++ b/SaplingMcp.Server/Services/Sapling.cs
@@ -266,6 +266,29 @@ public class Sapling
 
         return statuses;
     }
+
+    /// <summary>
+    /// Submits the current stack of commits to create or update pull requests.
+    /// </summary>
+    /// <returns>A list of commits in the stack that were submitted.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the submission fails.</exception>
+    public IList<Commit> SubmitStack()
+    {
+        try
+        {
+            // Run the 'sl pr submit' command to submit the current stack
+            var arguments = new List<string> { "pr", "submit" };
+            RunCommand(arguments);
+
+            // Return the updated stack with PR information
+            return Stack();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Error submitting stack: {ex.Message}");
+        }
+    }
+
     /// <summary>
     /// Runs a Sapling command with the specified arguments.
     /// </summary>


### PR DESCRIPTION

Summary:

Implemented functionality to submit the current stack of commits to create or update pull requests. This feature allows users to easily submit all commits in their stack and link them with PRs using a single command.

Key additions:
- Added SubmitStack method to Sapling service that executes 'sl pr submit'
- Added corresponding SubmitStack method to SaplingTools with MCP server tool annotation
- Implemented proper error handling and return of updated stack information
- Used token-efficient format for returning commit data

Test Plan:

1. Create multiple commits in a stack
2. Call the SubmitStack method
3. Verify that pull requests are created/updated for each commit in the stack
4. Check that the returned data contains the updated PR information
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/SaplingMcp/pull/6).
* #8
* #7
* __->__ #6