### PR TITLE
improvement: implement token-efficient pull request threads

### DIFF
--- a/SaplingMcp.Server/GitHubTools.cs
+++ b/SaplingMcp.Server/GitHubTools.cs
@@ -42,24 +42,65 @@ public class GitHubTools
         }
     }
 
+
     /// <summary>
-    /// Gets comments for a specific pull request.
+    /// Gets review threads for a specific pull request.
     /// </summary>
     /// <param name="prNumber">The pull request number.</param>
-    /// <param name="repo">Repository in the format owner/repo</param>
-    /// <returns>A list of comments on the pull request.</returns>
-    [McpServerTool, Description("Gets comments for a specific pull request")]
-    public List<PullRequestComment> GetPullRequestComments(
+    /// <param name="repo">Repository in the format owner/repo.</param>
+    /// <returns>A token-efficient formatted string of review threads, including their comments and resolved status.</returns>
+    [McpServerTool, Description("Gets review threads for a specific pull request, including comments and resolved status")]
+    public string GetPullRequestReviewThreads(
         [Description("The pull request number")] int prNumber,
         [Description("Repository in the format owner/repo")] string repo)
     {
         try
         {
-            return _github.GetPullRequestComments(prNumber, repo).ToList();
+            // Ensure the repo format is correct before passing it down
+            if (string.IsNullOrWhiteSpace(repo) || !repo.Contains('/'))
+            {
+                throw new ArgumentException("Repository must be in the format 'owner/repo'.");
+            }
+            var threads = _github.GetPullRequestReviewThreads(prNumber, repo);
+            return TokenEfficientParser.FormatReviewThreads(threads, prNumber, repo);
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"Error getting pull request comments: {ex.Message}");
+            // Propagate specific argument exceptions or wrap others
+            if (ex is ArgumentException) throw;
+            throw new InvalidOperationException($"Error getting pull request review threads: {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Gets unresolved review threads for a specific pull request.
+    /// </summary>
+    /// <param name="prNumber">The pull request number.</param>
+    /// <param name="repo">Repository in the format owner/repo.</param>
+    /// <returns>A token-efficient formatted string of unresolved review threads that need action.</returns>
+    [McpServerTool, Description("Gets unresolved review threads for a specific pull request that need action")]
+    public string GetUnresolvedPullRequestThreads(
+        [Description("The pull request number")] int prNumber,
+        [Description("Repository in the format owner/repo")] string repo)
+    {
+        try
+        {
+            // Ensure the repo format is correct before passing it down
+            if (string.IsNullOrWhiteSpace(repo) || !repo.Contains('/'))
+            {
+                throw new ArgumentException("Repository must be in the format 'owner/repo'.");
+            }
+
+            // Get all threads and filter to only unresolved ones
+            var allThreads = _github.GetPullRequestReviewThreads(prNumber, repo);
+            var unresolvedThreads = allThreads.Where(thread => !thread.IsResolved).ToList();
+            return TokenEfficientParser.FormatReviewThreads(unresolvedThreads, prNumber, repo);
+        }
+        catch (Exception ex)
+        {
+            // Propagate specific argument exceptions or wrap others
+            if (ex is ArgumentException) throw;
+            throw new InvalidOperationException($"Error getting unresolved pull request threads: {ex.Message}", ex);
         }
     }
 

--- a/SaplingMcp.Tests/TokenEfficientParserTests.cs
+++ b/SaplingMcp.Tests/TokenEfficientParserTests.cs
@@ -209,6 +209,173 @@ public class TokenEfficientParserTests
     }
 
     [Fact]
+    public void FormatReviewThread_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        var thread = new ReviewThread
+        {
+            IsResolved = false,
+            Comments = new ReviewThreadComments
+            {
+                Nodes = new List<PullRequestReviewComment>
+                {
+                    new PullRequestReviewComment
+                    {
+                        Author = new Author { Login = "testuser" },
+                        CreatedAt = "2023-10-27T10:00:00Z",
+                        Body = "Initial comment body.",
+                        DiffHunk = "@@ -1 +1 @@\n-old\n+new"
+                    }
+                }
+            }
+        };
+        var prNumber = 123;
+        var repoPath = "testorg/testrepo";
+
+        // Act
+        var result = TokenEfficientParser.FormatReviewThread(thread, prNumber, repoPath);
+
+        // Assert
+        Assert.Equal("pr:testorg/testrepo#123|resolved:false|comments:1|author:testuser|date:2023-10-27T10:00:00Z|body:Initial comment body.|diffHunk:@@ -1 +1 @@\\n-old\\n+new", result);
+    }
+
+    [Fact]
+    public void FormatReviewThreads_ShouldReturnMultilineFormat()
+    {
+        // Arrange
+        var threads = new List<ReviewThread>
+        {
+            new ReviewThread
+            {
+                IsResolved = true,
+                Comments = new ReviewThreadComments
+                {
+                    Nodes = new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment
+                        {
+                            Author = new Author { Login = "user1" },
+                            CreatedAt = "2023-10-27T10:00:00Z",
+                            Body = "Comment 1.",
+                            DiffHunk = "diff1"
+                        }
+                    }
+                }
+            },
+            new ReviewThread
+            {
+                IsResolved = false,
+                Comments = new ReviewThreadComments
+                {
+                    Nodes = new List<PullRequestReviewComment>
+                    {
+                        new PullRequestReviewComment
+                        {
+                            Author = new Author { Login = "user2" },
+                            CreatedAt = "2023-10-27T11:00:00Z",
+                            Body = "Comment 2.\nNew line.",
+                            DiffHunk = "diff2\\nwith newline"
+                        }
+                    }
+                }
+            }
+        };
+        var prNumber = 456;
+        var repoPath = "anotherorg/anotherrepo";
+
+        // Act
+        var result = TokenEfficientParser.FormatReviewThreads(threads, prNumber, repoPath);
+        var lines = result.Split(Environment.NewLine);
+
+        // Assert
+        Assert.Equal(2, lines.Length);
+        Assert.Equal("pr:anotherorg/anotherrepo#456|resolved:true|comments:1|author:user1|date:2023-10-27T10:00:00Z|body:Comment 1.|diffHunk:diff1", lines[0]);
+        Assert.Equal("pr:anotherorg/anotherrepo#456|resolved:false|comments:1|author:user2|date:2023-10-27T11:00:00Z|body:Comment 2.\\nNew line.|diffHunk:diff2\\\\nwith newline", lines[1]);
+    }
+
+    [Fact]
+    public void FormatReviewComment_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        var comment = new PullRequestReviewComment
+        {
+            Id = "comment789",
+            Author = new Author { Login = "reviewer" },
+            CreatedAt = "2023-10-28T09:00:00Z",
+            Body = "Looks good overall."
+        };
+
+        // Act
+        var result = TokenEfficientParser.FormatReviewComment(comment);
+
+        // Assert
+        Assert.Equal("id:comment789|author:reviewer|date:2023-10-28T09:00:00Z|body:Looks good overall.", result);
+    }
+
+    [Fact]
+    public void FormatReviewComments_ShouldReturnMultilineFormat()
+    {
+        // Arrange
+        var comments = new List<PullRequestReviewComment>
+        {
+            new PullRequestReviewComment
+            {
+                Id = "comment1",
+                Author = new Author { Login = "userA" },
+                CreatedAt = "2023-10-28T09:00:00Z",
+                Body = "Comment A."
+            },
+            new PullRequestReviewComment
+            {
+                Id = "comment2",
+                Author = new Author { Login = "userB" },
+                CreatedAt = "2023-10-28T10:00:00Z",
+                Body = "Comment B.\nWith newline."
+            }
+        };
+
+        // Act
+        var result = TokenEfficientParser.FormatReviewComments(comments);
+        var lines = result.Split(Environment.NewLine);
+
+        // Assert
+        Assert.Equal(2, lines.Length);
+        Assert.Equal("id:comment1|author:userA|date:2023-10-28T09:00:00Z|body:Comment A.", lines[0]);
+        Assert.Equal("id:comment2|author:userB|date:2023-10-28T10:00:00Z|body:Comment B.\\nWith newline.", lines[1]);
+    }
+
+    [Fact]
+    public void FormatReviewThread_ShouldReturnCorrectFormat()
+    {
+        // Arrange
+        var thread = new ReviewThread
+        {
+            IsResolved = false,
+            Comments = new ReviewThreadComments
+            {
+                Nodes = new List<PullRequestReviewComment>
+                {
+                    new PullRequestReviewComment
+                    {
+                        Author = new Author { Login = "testuser" },
+                        CreatedAt = "2023-10-27T10:00:00Z",
+                        Body = "Initial comment body.",
+                        DiffHunk = "@@ -1 +1 @@\n-old\n+new"
+                    }
+                }
+            }
+        };
+        var prNumber = 123;
+        var repoPath = "testorg/testrepo";
+
+        // Act
+        var result = TokenEfficientParser.FormatReviewThread(thread, prNumber, repoPath);
+
+        // Assert
+        Assert.Equal("pr:testorg/testrepo#123|resolved:false|comments:1|author:testuser|date:2023-10-27T10:00:00Z|body:Initial comment body.|diffHunk:@@ -1 +1 @@\\n-old\\n+new", result);
+    }
+
+    [Fact]
     public void UnescapeValue_ShouldHandleEscapedNewlines()
     {
         // Arrange


### PR DESCRIPTION

Summary:

Changed the pull request comments to use threads instead of individual comments.
This allows us to get the resolved status of threads and filter based on it.
Added token-efficient formatting for review threads to minimize token usage.

Test Plan:

1. Build the project with 'dotnet build'
2. Run tests with 'dotnet test'
3. Manually test the new API endpoints with a GitHub repository that has pull requests with review threads
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/AdeAttwood/SaplingMcp/pull/10).
* #9
* __->__ #10